### PR TITLE
Introduces the UnityArray<TYPE> class as wrapper for the shared arrays between C++ and C#

### DIFF
--- a/UnityForCppPlugin/Source/Shared.cpp
+++ b/UnityForCppPlugin/Source/Shared.cpp
@@ -1,0 +1,18 @@
+//Copyright (c) 2016, Samuel Pollachini (Samuel Polacchini)
+//This project is licensed under the terms of the MIT license
+
+#include "Shared.h"
+#include "UnityAdapter.h"
+
+namespace Shared
+{
+	void OutputDebugStr(const char* str)
+	{
+		UnityForCpp::UnityAdapter::OutputDebugStr(str);
+	}
+
+	void OnAssertionFailed(const char* sourceFileName, int sourceLineNumber)
+	{
+		UnityForCpp::UnityAdapter::OnAssertionFailed(__FILE__, __LINE__);
+	}
+}

--- a/UnityForCppPlugin/Source/Shared.h
+++ b/UnityForCppPlugin/Source/Shared.h
@@ -1,13 +1,16 @@
 //Copyright (c) 2016, Samuel Pollachini (Samuel Polacchini)
 //This project is licensed under the terms of the MIT license
 
+#ifndef SHARED_H
+#define SHARED_H
+
 #if _MSC_VER // this is defined when compiling with Visual Studio
 #define EXPORT_API __declspec(dllexport) // Visual Studio needs annotating exported functions with this
 #else
 #define EXPORT_API // XCode does not need annotating exported functions, so define is empty
 #endif
 
-#ifndef WIN32 //have debug as default when dropping cpp sources directly on Assets/Plugin folder for iOS and WebGL targets
+#ifndef WIN32 //have debug as default for when dropping cpp sources directly on Assets/Plugin folder for iOS and WebGL targets
 #define _DEBUG
 #endif
 
@@ -16,8 +19,33 @@
 #endif
 
 typedef unsigned int uint;
+typedef unsigned char uchar;
 
 #ifdef WIN32
 #define snprintf sprintf_s
 #endif
 
+#ifdef _DEBUG
+
+//Wrap UnityAdapter functions into Shared namespace functions, avoiding creating a dependency with UnityAdapter.h
+namespace Shared 
+{
+	void OutputDebugStr(const char* str);
+	void OnAssertionFailed(const char* sourceFileName, int sourceLineNumber);
+}
+
+//Log str to Unity console using "Debug.Log"
+#define DEBUG_LOG(str) Shared::OutputDebugStr(str)
+
+//When exp is false, logs its source file name and line before triggering an usual C assertion 
+#define ASSERT(exp) if (!(exp)) Shared::OnAssertionFailed(__FILE__, __LINE__)
+
+#else //release version
+#define DEBUG_LOG(str)
+#define ASSERT(str)
+#endif
+
+#define DELETE(ptr) delete ptr; \
+					ptr = NULL;
+
+#endif

--- a/UnityForCppPlugin/Source/TestPlugin.cpp
+++ b/UnityForCppPlugin/Source/TestPlugin.cpp
@@ -3,82 +3,88 @@
 
 #include "Shared.h"
 #include "UnityAdapter.h"
+#include "UnityArray.h"
 #include <stdio.h>
 
 namespace UnityAdapter = UnityForCpp::UnityAdapter;
+using UnityForCpp::UnityArray;
+
+namespace TestPlugin
+{
+	//We will change this int array from C++ and print the result from C#
+	static UnityArray<int>* nf_pIntUnityArray = NULL;
+
+	//We will change this float array from C# and print the result from C++
+	static UnityArray<float>* nf_pFloatUnityArray = NULL;
+}
 
 //Short code for testing the currently available UnityForCpp Features
 extern "C"
 {
 	//TEST_ARRAY_SIZE must be bigger than 4, since we print the first 4 items at T_PrintSharedFloatArrayFromCpp
 #define TEST_ARRAY_SIZE 4
-
-	//We will change this int array from C++ and print the result from C#
-	static int f_sharedIntArrayId = -1;
-	static int* f_sharedIntArray = NULL;
-
-	//We will change this float array from C# and print the result from C++
-	static int f_sharedFloatArrayId = -1;
-	static float* f_sharedFloatArray = NULL;	
-
+	
 	void EXPORT_API T_InitTest()
 	{
 		//TESTING FILE READING/WRITING FEATURES ----------------------------------
 
 		DEBUG_LOG("Requesting the FileTest.txt from C++");
-		int size;
-		char* fileContent = (char*) UnityAdapter::ReadFileContentToManagedArray("FileTest.txt", &size);
-		DEBUG_LOG(fileContent);
+		UnityArray<uchar>* pFileContent = UnityAdapter::ReadFileContentToUnityArray("FileTest.txt");
+		ASSERT(pFileContent);
+	
+		DEBUG_LOG((const char*) pFileContent->GetArrayPtr());
 
 		DEBUG_LOG("Saving the file TestFolder1/TestFolder2/FileSavingTest.txt from C++");
 		UnityAdapter::SaveTextFile("TestFolder1/TestFolder2/FileSavingTest.txt", "This was saved to a file from an UnityPlugin");
 
 		DEBUG_LOG("Loading the saved file and printing its content");
-		char* savedFileContent = (char*)UnityAdapter::ReadFileContentToManagedArray("TestFolder1/TestFolder2/FileSavingTest.txt", &size);
-		DEBUG_LOG(savedFileContent);
+		UnityArray<uchar>* pSavedFileContent = UnityAdapter::ReadFileContentToUnityArray("TestFolder1/TestFolder2/FileSavingTest.txt");
+		ASSERT(pSavedFileContent);
+
+		DEBUG_LOG((const char*)pSavedFileContent->GetArrayPtr());
 
 		DEBUG_LOG("Deleting the file FileSavingTest.txt from C++");
 		UnityAdapter::DeleteFile("TestFolder1/TestFolder2/FileSavingTest.txt");
 
+		//test the file was successfully deleted above
+		pSavedFileContent = UnityAdapter::ReadFileContentToUnityArray("TestFolder1/TestFolder2/FileSavingTest.txt");
+		ASSERT(pSavedFileContent == NULL);
+		DEBUG_LOG("We have successfully deleted the file FileSavingTest.txt!");
+
 		//release both file contents we have loaded
-		UnityAdapter::ReleaseManagedArray(fileContent);
-		UnityAdapter::ReleaseManagedArray(savedFileContent);
+		DELETE(pFileContent);
+		DELETE(pSavedFileContent);
 
 		//TESTING SHARED ARRAYS		
 		//Since the arrays are requested and released from a C++ code "decision", it is like C++ owns the arrays, so we
 		//initialize their values here, even for the float array that is mostly intended to be written from the C# code
 
 		DEBUG_LOG("Requesting shared arrays from C++ code");
-
-		f_sharedIntArrayId = UnityAdapter::NewManagedArray<int>(TEST_ARRAY_SIZE);
-		f_sharedIntArray = UnityAdapter::GetManagedArray<int>(f_sharedIntArrayId);
-
+		TestPlugin::nf_pIntUnityArray = new UnityArray<int>(TEST_ARRAY_SIZE);
 		for (int i = 0; i < TEST_ARRAY_SIZE; ++i)
-			f_sharedIntArray[i] = 0;
+			(*TestPlugin::nf_pIntUnityArray)[i] = 0;
 
-		f_sharedFloatArrayId = UnityAdapter::NewManagedArray<float>(TEST_ARRAY_SIZE);
-		f_sharedFloatArray = UnityAdapter::GetManagedArray<float>(f_sharedFloatArrayId);
+		TestPlugin::nf_pFloatUnityArray = new UnityArray<float>(TEST_ARRAY_SIZE);
+		for (int i = 0; i < TEST_ARRAY_SIZE; ++i)
+			(*TestPlugin::nf_pFloatUnityArray)[i] = 0;
 		
-		for (int i = 0; i < TEST_ARRAY_SIZE; ++i)
-			f_sharedFloatArray[i] = 0.0f;
-
 		DEBUG_LOG("The shared arrays have been delivered and initialized with success");
 	}
 
 	int EXPORT_API T_GetSharedIntArrayId()
 	{
-		return f_sharedIntArrayId;
+		return TestPlugin::nf_pIntUnityArray->GetId();
 	}
 
 	int EXPORT_API T_GetSharedFloatArrayId()
 	{
-		return f_sharedFloatArrayId;
+		return TestPlugin::nf_pFloatUnityArray->GetId();
 	}
 
 	void EXPORT_API T_ChangeSharedIntArray()
 	{
 		for (int i = 0; i < TEST_ARRAY_SIZE; ++i)
-			f_sharedIntArray[i] += 1;
+			(*TestPlugin::nf_pIntUnityArray)[i] += 1;
 	}
 
 	void EXPORT_API T_PrintSharedFloatArray()
@@ -88,21 +94,14 @@ extern "C"
 		outputStr[255] = 0; //make sure it will be zero terminated
 		snprintf(outputStr, 255, 
 			     "First 4 values of the float array being printed from C++: %.2f %.2f %.2f %.2f", 
-				 f_sharedFloatArray[0], f_sharedFloatArray[1], f_sharedFloatArray[2], f_sharedFloatArray[3]);
+				 (*TestPlugin::nf_pFloatUnityArray)[0], (*TestPlugin::nf_pFloatUnityArray)[1], (*TestPlugin::nf_pFloatUnityArray)[2], (*TestPlugin::nf_pFloatUnityArray)[3]);
 
 		DEBUG_LOG(outputStr);
 	}
 
 	void EXPORT_API T_TerminateTest()
 	{
-		//Set values back to their initial values, since the Unity Editor may restart the test execution
-		f_sharedIntArrayId = -1;
-		f_sharedIntArray = NULL;
-
-		f_sharedFloatArrayId = -1;
-		f_sharedFloatArray = NULL;
-		
-		//Release the shared arrays
-		UnityAdapter::ReleaseAllManagedArrays();
+		DELETE(TestPlugin::nf_pIntUnityArray);
+		DELETE(TestPlugin::nf_pFloatUnityArray);
 	}
 } // end of export C block

--- a/UnityForCppPlugin/Source/UnityAdapter.cpp
+++ b/UnityForCppPlugin/Source/UnityAdapter.cpp
@@ -2,6 +2,7 @@
 //This project is licensed under the terms of the MIT license
 
 #include "UnityAdapter.h"
+#include "UnityArray.h"
 #include <assert.h>
 #include <stdio.h>
 
@@ -11,43 +12,45 @@ namespace UnityAdapter
 {
 namespace Internals
 {
-
-//Use this macro for supporting new array types (https://msdn.microsoft.com/en-us/library/ya5y69ds.aspx).
-//IMPORTANT: Be sure about type compatibility between C# and your required platforms. A type correspondency 
-//that works well on one platform may not work at other platform. 
-//For Visual C++ types correspondency check https://msdn.microsoft.com/en-us/library/0wf2yk2k.aspx
-#define UA_SUPPORTED_TYPE(cpp_type, cs_name) template<> const char* GetManagedTypeName<cpp_type>() { return #cs_name; }
-
-	//Currently supported array types
-	UA_SUPPORTED_TYPE(void, System.Byte)
-	UA_SUPPORTED_TYPE(int, System.Int32)
-	UA_SUPPORTED_TYPE(uint, System.UInt32)
-	UA_SUPPORTED_TYPE(float, System.Single)
-
-	//struct to hold the required info to manage the arrays currently shared between C# and C++
-	//We make a simple linked list between instances of it using the "pNext" field.
-	typedef struct _ArrayInfo
+	//struct to hold the received array pointer and info, also used to access the private contructor from UnityArray<>
+	struct DeliveredManagedArray
 	{
 		int id;
-		const char* managedTypeName;
-		int size;
+		int count;
 		void* pArray;
-		struct _ArrayInfo* pNext;
 
-		_ArrayInfo()
-			: id(-1), managedTypeName(NULL), size(0), pArray(NULL), pNext(NULL) {}
+		DeliveredManagedArray()
+			: id(-1), count(0), pArray(NULL) {}
 
-		_ArrayInfo(const struct _ArrayInfo& ai)
-			: id(ai.id), managedTypeName(ai.managedTypeName), size(ai.size), pArray(ai.pArray), pNext(NULL) {}
-	} ArrayInfo;
+		DeliveredManagedArray(int _id, int _count, void* _pArray)
+			: id(_id), count(_count), pArray(_pArray) {}
 
+		//provides an way for UnityAdapter functions be able to receive arrays from C# and deliver them directly as UnityArray<>
+		template <typename T> UnityArray<T>* GetAsNewUnityArray()
+		{
+			return new UnityArray<T>(id, count, pArray);
+		}
+	};
+
+	//ALWAYS USE THIS WITH "pNextToGet=NULL" TO RETRIEVE THE DELIVERED ARRAY FROM UA_DeliverManagedArray DLL function
+	//if the returned struct has pArray == NULL, this means the C# code could not deliver the requested array
+	//This method is as it is in order to prevent possible wrong manipulations with the received array info by the user functions
+	DeliveredManagedArray GetDeliveredManagedArrayAndSetNext(DeliveredManagedArray* pNextToGet)
+	{
+		static DeliveredManagedArray c_deliveredManagedArray = DeliveredManagedArray();
+
+		//Assert we have no forgot delivered array, previously delivered, but not properly acquired
+		ASSERT(c_deliveredManagedArray.pArray == NULL || pNextToGet == NULL);
+
+		DeliveredManagedArray returnValue = c_deliveredManagedArray;
+		c_deliveredManagedArray = pNextToGet ? *pNextToGet : DeliveredManagedArray();
+
+		return returnValue;
+	}
+
+	//----------------
 	//"f" prefix stands for file variable (C static variable), "g" for global variable, "n" for namaspace global variable
 	//"s" for class static attribute, "m" for class instance attribute, "c" for function static variables
-
-	static ArrayInfo*					nf_pArrayInfoLinkedListHead = NULL; //ArrayInfo linked list head
-
-	//When the C# codes calls DeliverRequestedManagedArray, the returned C# array info is saved here
-	static ArrayInfo					nf_justDeliveredArrayInfo = ArrayInfo();
 
 	//C# function pointers to be set right after the DLL loading via the UnityAdapterPlugin interface
 	static OutputDebugStrFcPtr			nf_OutputDebugStr = NULL;
@@ -55,59 +58,6 @@ namespace Internals
 	static SaveTextFileFcPtr			nf_SaveTextFile = NULL;
 	static RequestManagedArrayFcPtr		nf_RequestManagedArray = NULL;
 	static ReleaseManagedArrayFcPtr		nf_ReleaseManagedArray = NULL;
-
-	//If the C# code has delivered an array by calling DeliverRequestedManagedArray this method will
-	//create a new ArrayInfo node and insert it on ArrayInfo simple linked list
-	ArrayInfo* AcquireDeliveredArray()
-	{
-		if (nf_justDeliveredArrayInfo.pArray == NULL)
-			return NULL;
-
-		ArrayInfo* pNewArrayInfo = new ArrayInfo(nf_justDeliveredArrayInfo);
-		nf_justDeliveredArrayInfo.pArray = NULL; //**reset it for next usage**
-
-		//keep things simple by just inserting the new linked list node on the front of the list
-		pNewArrayInfo->pNext = nf_pArrayInfoLinkedListHead;
-		nf_pArrayInfoLinkedListHead = pNewArrayInfo;
-
-		return nf_pArrayInfoLinkedListHead;
-	}
-
-	//check NewManagedArray<T>(...) declaration for comments
-	int NewManagedArray(int size, const char* managedTypeName)
-	{
-		ASSERT(nf_RequestManagedArray);
-		nf_RequestManagedArray(managedTypeName, size);
-		ArrayInfo* pArrayInfo = AcquireDeliveredArray();
-		ASSERT(pArrayInfo != NULL);
-		pArrayInfo->managedTypeName = managedTypeName;
-		return pArrayInfo->id;
-	}
-
-	//check GetManagedArray<T>(...) declaration for comments
-	void* GetManagedArray(int arrayId, int* pSizeOutput, const char* managedTypeName)
-	{
-		ArrayInfo* pArrayInfo = nf_pArrayInfoLinkedListHead;
-		while (pArrayInfo != NULL)
-		{
-			if (pArrayInfo->id == arrayId)
-			{
-				ASSERT(managedTypeName == pArrayInfo->managedTypeName); //assure type safety by comparing static string addresses
-				if (pSizeOutput)
-					*pSizeOutput = pArrayInfo->size;
-
-				return pArrayInfo->pArray;
-			}
-
-			pArrayInfo = pArrayInfo->pNext;
-		}
-
-		return NULL;
-	}
-
-
-	//----------------
-
 
 	void SetOutputDebugStrFcPtr(OutputDebugStrFcPtr fcPtr)
 	{
@@ -129,64 +79,50 @@ namespace Internals
 		nf_ReleaseManagedArray = releaseManagedArrayFcPtr;
 	}
 
-	void DeliverRequestedManagedArray(int id, void* pArray, int size)
+	void DeliverRequestedManagedArray(int id, void* pArray, int count)
 	{
 		if (!pArray)
 			return;
 
-		//after this function has returned and the enclosing C# function has also returned
-		//AcquireDeliveredArray handle the delivered array inserting its info at the linked list
-		nf_justDeliveredArrayInfo.managedTypeName = NULL; //To be set by the requester function
-		nf_justDeliveredArrayInfo.id = id;
-		nf_justDeliveredArrayInfo.pArray = pArray;
-		nf_justDeliveredArrayInfo.size = size;
+		DeliveredManagedArray deliveredArray(id, count, pArray);
+		GetDeliveredManagedArrayAndSetNext(&deliveredArray);
 	}
 
 } //Internals
 
 //check declaration for comments
-void ReleaseManagedArray(void* pArray)
+int NewManagedArray(const char* managedTypeName, int count, void** pOutputArrayPtr)
 {
-	ASSERT(Internals::nf_ReleaseManagedArray);
-	Internals::ArrayInfo* pArrayInfo = Internals::nf_pArrayInfoLinkedListHead;
-	Internals::ArrayInfo** ppArrayInfo = &Internals::nf_pArrayInfoLinkedListHead;
+	ASSERT(Internals::nf_RequestManagedArray);
+	ASSERT(pOutputArrayPtr);
 
-	while (pArrayInfo != NULL)
-	{
-		if (pArrayInfo->pArray == pArray)
-		{
-			Internals::nf_ReleaseManagedArray(pArrayInfo->id);
-			*ppArrayInfo = pArrayInfo->pNext;
-			delete pArrayInfo;
-			return;
-		}
-		ppArrayInfo = &(pArrayInfo->pNext);
-		pArrayInfo = pArrayInfo->pNext;
-	}
+	Internals::nf_RequestManagedArray(managedTypeName, count);
+	struct Internals::DeliveredManagedArray deliveredArray = Internals::GetDeliveredManagedArrayAndSetNext(NULL);
 
-	ASSERT(false); //array not found, likely a duplicated release
-}
+	ASSERT(deliveredArray.pArray != NULL);
 
-void ReleaseAllManagedArrays()
-{
-	while (Internals::nf_pArrayInfoLinkedListHead != NULL)
-		ReleaseManagedArray(Internals::nf_pArrayInfoLinkedListHead->pArray);
+	*pOutputArrayPtr = deliveredArray.pArray;
+	return deliveredArray.id;
 }
 
 //check declaration for comments
-void* ReadFileContentToManagedArray(const char* fullFilePath, int* pSizeOutput)
+void ReleaseManagedArray(int arrayId)
+{
+	ASSERT(Internals::nf_ReleaseManagedArray);
+	Internals::nf_ReleaseManagedArray(arrayId);
+}
+
+//check declaration for comments
+UnityArray<uchar>* ReadFileContentToUnityArray(const char* fullFilePath)
 {
 	ASSERT(Internals::nf_RequestFileContent);
 	Internals::nf_RequestFileContent(fullFilePath);
-	Internals::ArrayInfo* pArrayInfo = Internals::AcquireDeliveredArray();
-	if (pArrayInfo == NULL)
+	struct Internals::DeliveredManagedArray deliveredArray = Internals::GetDeliveredManagedArrayAndSetNext(NULL);
+
+	if (deliveredArray.pArray == NULL)
 		return NULL;
 
-	pArrayInfo->managedTypeName = Internals::GetManagedTypeName<void>();
-	if (pSizeOutput != NULL)
-		*pSizeOutput = pArrayInfo->size;
-
-	return pArrayInfo->pArray;
+	return deliveredArray.GetAsNewUnityArray<uchar>();
 }
 
 //check declaration for comments

--- a/UnityForCppPlugin/Source/UnityAdapter.h
+++ b/UnityForCppPlugin/Source/UnityAdapter.h
@@ -6,21 +6,11 @@
 
 #include "Shared.h"
 
-#ifdef _DEBUG
-
-//Log str to Unity console using "Debug.Log"
-#define DEBUG_LOG(str) UnityForCpp::UnityAdapter::OutputDebugStr(str)
-
-//When exp is false, logs its source file name and line before triggering an usual C assertion 
-#define ASSERT(exp) if (!(exp)) UnityForCpp::UnityAdapter::OnAssertionFailed(__FILE__, __LINE__)
-
-#else //release version
-#define DEBUG_LOG(str)
-#define ASSERT(str)
-#endif
 
 namespace UnityForCpp
 {
+
+template <typename T> class UnityArray;
 
 //Provides unity multiplatform features to the C++ code
 //Works associated with UnityAdapter.cs at the C# side using UnityAdapterPlugin.cpp for interop
@@ -29,39 +19,15 @@ namespace UnityAdapter
 {
 // -------------------------- UNITY ADAPTER UTILITIES FOR THE CPP CODE ----------------------------
 
-// Shared memory utilities --------------------------
-
-//Gets an existing shared/managed array and (optionally) its size, if a non-null pSizeOutput is provided
-//IMPORTANT: type safety check at runtime. Requesting the array with the wrong type results on a assertion
-//Check NewManagedArray comments for more info about the possible types
-template <typename T> T* GetManagedArray(int arrayId, int* pSizeOutput = NULL);
-
-//Request a new shared/managed (C#) array, having the given "size" and type (<T>), to the C# code.
-//Returns the arrayId for received array, use it with GetManagedArray above in order to retrive the array itself
-//Also this array id allows the shared array to be found by the C# code, once you provide it to the C# code. 
-//For checking/extending the possible array types, check the usage of the macro UA_SUPPORTED_TYPE on UnityAdapter.cpp
-//This method should never fail, if it does a C assertion will be triggered.
-template <typename T> int NewManagedArray(int size);
-
-//Release the shared/managed C# array by providing its head pointer
-//if the corresponding array info is not found an assertion will be triggered (possibly duplicated release)
-void ReleaseManagedArray(void* pArray);
-
-//Released all the managed arrays currently being held by the C++ code.
-//IMPORTANT: make your logic to get aware about the execution end of a given "play" from the Unity Editor and call
-//this function to be sure you are not leaving any allocated arrays between to game replays
-void ReleaseAllManagedArrays();
-
-
 // File utilities ----------------------------------
 
-//Open the file as TextAsset and read its content to a managed array and returns it or returns NULL if not found.
-//You must release this array with ReleaseManagedArray when you are done with it.
+//Open the file as TextAsset and read its content to an unity array and returns it or returns NULL if not found.
+//YOU *OWN* THIS UnityArray OBJECT AND SHOULD DELETE IT WHEN YOU ARE DONE.
 //fullFilePath may (and should) include the file extension.
 //pSizeOutput is optional, since a text file content should ends with 0, but it's better to provided and rely on it.
 //The search *goes first* for existing saved files and after for bundle files. Saved files will have the persistent
 //data folder as path root. Bundle files are expected to have an Assets "Resources" folder as path root.
-void* ReadFileContentToManagedArray(const char* fullFilePath, int* pSizeOutput);
+UnityArray<uchar>* ReadFileContentToUnityArray(const char* fullFilePath);
 
 //Save the contentStr data to the file at the specified path (creates file and directory if needed).
 //The persistent data folder for the platform will be the path root. An existing file for this path will be overwriten.
@@ -70,19 +36,33 @@ void SaveTextFile(const char* fullFilePath, const char* contentStr);
 //Deletes the file at the specified path if it exists. The persistent data folder for the platform will be the path root. 
 void DeleteFile(const char* fullFilePath);
 
-
 // Debug utilities ----------------------------------
 
-//Check comments for the DEBUG_LOG macro
+//Check comments for the DEBUG_LOG macro, use it instead
 void OutputDebugStr(const char* strToLog);
 
-//Check comments for the ASSERT macro
+//Check comments for the ASSERT macro, use it instead
 void OnAssertionFailed(const char* sourceFileName, int sourceLineNumber); //use macro instead
+
+// Shared memory utilities -----------------
+
+//PREFER USING UnityArray<TYPE> INSTEAD
+//This method request a new shared/managed (C#) array, having the given "size" and type specified by its .NET type.
+//Returns the arrayId for received array, which can be provided to the C# code as an way for this to use the array
+//For checking the possible array types, check the usage of the macro UA_SUPPORTED_TYPE on UnityArray.cpp
+//This method should never fail, if it does a C assertion will be triggered.
+int NewManagedArray(const char* managedTypeName, int count, void** pOutputArrayPtr);
+
+//Release the shared/managed C# array
+void ReleaseManagedArray(int arrayId);
+
 
 //namespace to separate actual utilities offered by UnityAdapter to the cpp code from the internal namespace stuff
 //providing this implementation and that needs to be accessible to UnityAdapterPlugin.h
 namespace Internals
 { 
+	struct DeliveredManagedArray;
+
 	// ---------------------- Interface for C++/C# communication through the UnityAdapterPlugin -------------------
 
 	//At C# UnityForCpp.UnityAdapter.UnityAdapterDLL defines delegates for each one of these function pointer types
@@ -106,43 +86,11 @@ namespace Internals
 	//Check for comments at UnityAdapterPlugin.h
 	void DeliverRequestedManagedArray(int id, void* pArray, int size);
 
-	//forward declaration of functions needed for defining the template functions, check UnityAdapter.cpp for comments about them
-	template <typename T> const char* GetManagedTypeName();
-	void* GetManagedArray(int arrayId, int* pSizeOutput, const char* managedTypeName);
-	int NewManagedArray(int size, const char* managedTypeName);
 } //Internals namespace
 
-
-// ----------------------- Default Template functions' definition ----------------------------
-template <typename T>
-inline T* GetManagedArray(int arrayId, int* pSizeOutput)
-{
-	return reinterpret_cast<T*>(Internals::GetManagedArray(arrayId, pSizeOutput, Internals::GetManagedTypeName<T>()));
-}
-
-template <typename T>
-inline int NewManagedArray(int size)
-{
-	return Internals::NewManagedArray(size, Internals::GetManagedTypeName<T>());
-}
-
-
 } //UnityAdapter namespace
+
 } //UnityForCpp namespace
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/UnityForCppPlugin/Source/UnityArray.cpp
+++ b/UnityForCppPlugin/Source/UnityArray.cpp
@@ -1,0 +1,40 @@
+//Copyright (c) 2016, Samuel Pollachini (Samuel Polacchini)
+//This project is licensed under the terms of the MIT license
+
+#include "Shared.h"
+#include "UnityArray.h"
+#include "UnityAdapter.h"
+
+
+namespace UnityForCpp
+{
+
+//Use this macro for supporting new array types (https://msdn.microsoft.com/en-us/library/ya5y69ds.aspx).
+//IMPORTANT: Be sure about type compatibility between C# and your required platforms. A type correspondency 
+//that works well on one platform may not work at other platform. 
+//For Visual C++ types correspondency check https://msdn.microsoft.com/en-us/library/0wf2yk2k.aspx
+#define UA_SUPPORTED_TYPE(cpp_type, cs_name) \
+	template<> const char* const UnityArray<cpp_type>::s_cppTypeName = #cpp_type; \
+	template<> const char* const UnityArray<cpp_type>::s_managedTypeName = #cs_name;
+
+	//Currently supported array types
+	UA_SUPPORTED_TYPE(uchar, System.Byte)
+	UA_SUPPORTED_TYPE(int, System.Int32)
+	UA_SUPPORTED_TYPE(uint, System.UInt32)
+	UA_SUPPORTED_TYPE(float, System.Single)
+
+	UnityArrayBase::UnityArrayBase(const char* managedTypeName, int count)
+		: m_count(count)
+	{
+		m_id = UnityAdapter::NewManagedArray(managedTypeName, count, &m_pArray);
+	}
+
+	UnityArrayBase::UnityArrayBase(int id, int count, void* pArray)
+		: m_id(id), m_count(count), m_pArray(pArray) {}
+
+	UnityArrayBase::~UnityArrayBase()
+	{
+		UnityAdapter::ReleaseManagedArray(GetId());
+	}
+
+}

--- a/UnityForCppPlugin/Source/UnityArray.h
+++ b/UnityForCppPlugin/Source/UnityArray.h
@@ -1,0 +1,93 @@
+//Copyright (c) 2016, Samuel Pollachini (Samuel Polacchini)
+//This project is licensed under the terms of the MIT license
+
+#ifndef UNITY_ARRAY_H
+#define UNITY_ARRAY_H
+
+namespace UnityForCpp
+{
+	//required foward declaration
+	namespace UnityAdapter {
+		namespace Internals {
+			struct DeliveredManagedArray;
+		}
+	}
+
+//Non-template base class for our UnityArray template class, a pointer to it may hold any instance of its UnityArray<> subclasses
+//This is an ABSTRACT class, instance UnityArray<TYPE> instead. You may delete an instance of it from a pointer to UnityArrayBase.
+class UnityArrayBase
+{
+public:
+	//Get the array id, being in common with the id at the C# side, so pass it to C# and access this array from there too
+	int GetId() const { return m_id; }
+
+	//array size (number of items)
+	int GetCount() const { return m_count; }
+
+	//C++ type name, for a given UnityArray<T> subclass, not only the string, but also the ptr WILL BE ALWAYS THE SAME for all  
+	//instances, so a ptr comparison can be used to check if two instances of UnityArrayBase share the same type
+	virtual const char* GetCppTypeName() const = 0;
+
+	//.NET type name, this will always be the same for a given cpp type
+	virtual const char* GetManagedTypeArray() const = 0;
+
+	virtual ~UnityArrayBase();
+
+protected:
+	UnityArrayBase(const char* managedTypeName, int count);
+	UnityArrayBase(int id, int count, void* pArray);
+
+	int m_id;
+	int m_count;
+	void* m_pArray;
+};
+
+//Class to wrap shared arrays between C++ and C#. You may instance it directly with the "new" operator.
+//ONCE INSTANCED OWENERSHIP OF THE INSTANCE MUST BE STABLISHED AND THE IT MUST BE PROPERLY DELETED WITH "delete" (or "DELETE" macro)
+//Your code should delete all the instances of UnityArray when the game is stopped from the Unity Editor in order to start a
+//new gameplay without remaining allocated memory from previous plays.
+//FOR CHECKING/EXTENDING THE SUPPORTED TYPES look for the "UA_SUPPORTED_TYPE" macro usage at UnityArray.cpp
+template <typename T>
+class UnityArray : public UnityArrayBase
+{
+public:
+	//cpp type name as static const variable, its ptr value never changes for a given C++ type
+	static const char* const s_cppTypeName;
+
+	//C# type name as static const variable, its ptr value never changes for a given C++ type
+	static const char* const s_managedTypeName;
+
+	//Use this constructor with the "new" operator for instance a new UnityArray with the size "count"
+	UnityArray(int count)
+		: UnityArrayBase(s_managedTypeName, count) {}
+
+	virtual const char* GetCppTypeName() const { return s_cppTypeName; }
+	virtual const char* GetManagedTypeArray() const { return s_managedTypeName; }
+
+	T* GetArrayPtr() { return reinterpret_cast<T*>(m_pArray); }
+
+	const T& operator[](int i) const
+	{
+		ASSERT(i >= 0 && i < m_count);
+		return GetArrayPtr()[i];
+	}
+
+	T& operator[](int i)
+	{
+		ASSERT(i >= 0 && i < m_count);
+		return GetArrayPtr()[i];
+	}
+
+private:
+	//DeliveredManagedArray struct may use this constructor for dropping newly delivered arrays directly on a UnityArray instance
+	UnityArray(int id, int count, void* pArray)
+		: UnityArrayBase(id, count, pArray) {};
+
+	friend struct UnityAdapter::Internals::DeliveredManagedArray;
+};
+
+} //UnityForCpp namespace
+
+
+
+#endif

--- a/UnityForCppPlugin/WinProj/UnityForCpp.vcxproj
+++ b/UnityForCppPlugin/WinProj/UnityForCpp.vcxproj
@@ -19,12 +19,15 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\Source\Shared.cpp" />
     <ClCompile Include="..\Source\TestPlugin.cpp" />
     <ClCompile Include="..\Source\UnityAdapter.cpp" />
     <ClCompile Include="..\Source\UnityAdapterPlugin.cpp" />
+    <ClCompile Include="..\Source\UnityArray.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Source\Shared.h" />
+    <ClInclude Include="..\Source\UnityArray.h" />
     <ClInclude Include="..\Source\UnityAdapter.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/UnityForCppPlugin/WinProj/UnityForCpp.vcxproj.filters
+++ b/UnityForCppPlugin/WinProj/UnityForCpp.vcxproj.filters
@@ -15,12 +15,21 @@
     <ClCompile Include="..\Source\TestPlugin.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\UnityArray.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Source\Shared.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Source\UnityAdapter.h">
       <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="..\Source\Shared.h">
+      <Filter>Source</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\UnityArray.h">
       <Filter>Source</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
CHANGES FROM SamWork BRANCH (tested on windows, iOS and WebGL):
- UnityAdapter is not any more a manager for shared/managed arrays, now
  it just provides the basic feature of creating and returning them
- UnityForCpp::UnityArray<TYPE> should be used now for creating,
  manipulating and releasing shared/managed arrays
- Those who creates UnityArray<TYPE> with the "new" operator _owns_ the
  unity array instances and should delete them when done
- File reading feature from UnityAdapter was changed to use
  UnityArray<uchar> as its return type given away the ownership of it to
  the caller
- Moved DEBUG_LOG and ASSERT macros from UnityAdapter to Shared and
  adjusted them so no unecessary dependency from UnityAdapter.h needs to
  be stablished
